### PR TITLE
Make episode description expandable

### DIFF
--- a/app/src/main/java/tw/jizah/popocast/ui/channel/Channel.kt
+++ b/app/src/main/java/tw/jizah/popocast/ui/channel/Channel.kt
@@ -31,10 +31,7 @@ import tw.jizah.popocast.model.ChannelItem
 import tw.jizah.popocast.model.EpisodeItem
 import tw.jizah.popocast.ui.theme.Colors
 import tw.jizah.popocast.ui.theme.Dimens
-import tw.jizah.popocast.widget.CenterRow
-import tw.jizah.popocast.widget.CollapsingTopSection
-import tw.jizah.popocast.widget.EllipsisText
-import tw.jizah.popocast.widget.ExpandableWidget
+import tw.jizah.popocast.widget.*
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -207,11 +204,12 @@ fun ChannelPage(channelItem: ChannelItem) {
                         isFollowed = channelItem.isFollowed,
                         modifier = Modifier.fillMaxWidth().padding(horizontal = Dimens.m4)
                     )
-                    ExpandedDescription(
+                    ExpandableText(
+                        text = channelItem.description,
+                        maxLines = 2,
                         expandedState = expandedState,
                         modifier = Modifier.fillMaxWidth().padding(horizontal = Dimens.m4)
-                            .padding(top = Dimens.m3),
-                        description = channelItem.description
+                            .padding(top = Dimens.m3)
                     )
                     CategoryList(
                         items = channelItem.categoryList,
@@ -237,57 +235,6 @@ fun ChannelPage(channelItem: ChannelItem) {
 }
 
 @Composable
-private fun ExpandedDescription(
-    expandedState: MutableState<Boolean>,
-    modifier: Modifier,
-    description: String
-) {
-
-    fun toggleDescription() {
-        expandedState.value = !expandedState.value
-    }
-
-    ExpandableWidget(
-        modifier = modifier,
-        expandedState = expandedState,
-        expandedContent = {
-            Text(
-                text = description,
-                color = Colors.gray400
-            )
-            CenterRow(modifier = Modifier.clickable(onClick = { toggleDescription() }))  {
-                Text(
-                    text = stringResource(id = R.string.see_less),
-                    color = Colors.white,
-                    fontWeight = FontWeight.Bold
-                )
-                IconButton(onClick = { toggleDescription() }) {
-                    Icon(Icons.Default.ExpandLess, tint = Colors.white)
-                }
-            }
-        },
-        collapsedContent = {
-            EllipsisText(
-                text = description,
-                maxLines = 2,
-                color = Colors.gray400
-            )
-            CenterRow(modifier = Modifier.clickable(onClick = { toggleDescription() })) {
-                Text(
-                    text = stringResource(id = R.string.see_more),
-                    color = Colors.white,
-                    fontWeight = FontWeight.Bold
-                )
-                IconButton(
-                    onClick = { toggleDescription() }) {
-                    Icon(Icons.Default.ExpandMore, tint = Colors.white)
-                }
-            }
-        }
-    )
-}
-
-@Composable
 private fun CategoryList(modifier: Modifier, items: List<CategoryItem>) {
     LazyRowFor(items = items, modifier = modifier.fillMaxWidth()) { item ->
         OutlinedButton(
@@ -306,18 +253,18 @@ private fun CategoryList(modifier: Modifier, items: List<CategoryItem>) {
     }
 }
 
-@Preview
-@Composable
-fun ExpandingTextPreview() {
-    ExpandableWidget(
-        expandedContent = {
-            Text(text = "This is introduction. This is introduction. This is introduction.\nThis is introduction\nThis is introduction\nThis is introduction")
-        },
-        collapsedContent = {
-            Text(text = "This is introduction. This is introduction. This is introduction.\nThis is introduction\nThis is introduction\nThis is introduction")
-        }
-    )
-}
+//@Preview
+//@Composable
+//fun ExpandingTextPreview() {
+//    ExpandableWidget(
+//        expandedContent = {
+//            Text(text = "This is introduction. This is introduction. This is introduction.\nThis is introduction\nThis is introduction\nThis is introduction")
+//        },
+//        collapsedContent = {
+//            Text(text = "This is introduction. This is introduction. This is introduction.\nThis is introduction\nThis is introduction\nThis is introduction")
+//        }
+//    )
+//}
 
 @Preview
 @Composable

--- a/app/src/main/java/tw/jizah/popocast/utils/StringUtils.kt
+++ b/app/src/main/java/tw/jizah/popocast/utils/StringUtils.kt
@@ -1,0 +1,14 @@
+package tw.jizah.popocast.utils
+
+import android.text.Spanned
+import androidx.core.text.HtmlCompat
+
+object StringUtils {
+    fun styleHtmlText(text: String): Spanned {
+        val htmlLineBreak = "<br>"
+        return HtmlCompat.fromHtml(
+            text.replace("\n", htmlLineBreak),
+            HtmlCompat.FROM_HTML_MODE_LEGACY
+        )
+    }
+}

--- a/app/src/main/java/tw/jizah/popocast/widget/ClickTextTouchListener.kt
+++ b/app/src/main/java/tw/jizah/popocast/widget/ClickTextTouchListener.kt
@@ -1,0 +1,42 @@
+package tw.jizah.popocast.widget
+
+import android.text.Spanned
+import android.text.style.ClickableSpan
+import android.view.MotionEvent
+import android.view.View
+import android.view.View.OnTouchListener
+import android.widget.TextView
+
+class ClickTextTouchListener : OnTouchListener {
+
+    override fun onTouch(v: View, event: MotionEvent): Boolean {
+        val action = event.action
+        if (action == MotionEvent.ACTION_UP) {
+            return false
+        }
+
+        val widget = v as TextView
+        val text = widget.text
+        if (text is Spanned) {
+            var x = event.x
+            var y = event.y
+
+            x -= widget.totalPaddingLeft
+            y -= widget.totalPaddingTop
+
+            x += widget.scrollX
+            y += widget.scrollY
+
+            val layout = widget.layout
+            val line = layout.getLineForVertical(y.toInt())
+            val off = layout.getOffsetForHorizontal(line, x)
+
+            val links = text.getSpans(off, off, ClickableSpan::class.java)
+
+            if (links.isNotEmpty()) {
+                links[0].onClick(widget)
+            }
+        }
+        return true
+    }
+}

--- a/app/src/main/java/tw/jizah/popocast/widget/ExpandableWidget.kt
+++ b/app/src/main/java/tw/jizah/popocast/widget/ExpandableWidget.kt
@@ -1,29 +1,85 @@
 package tw.jizah.popocast.widget
 
+import android.text.TextUtils
+import android.text.util.Linkify
+import android.view.ViewGroup
+import android.widget.TextView
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.widget.TextViewCompat
+import tw.jizah.popocast.R
+import tw.jizah.popocast.ui.theme.Colors
+import tw.jizah.popocast.utils.StringUtils
 
 @Composable
 fun ExpandableWidget(
-    expandedState: MutableState<Boolean> = remember { mutableStateOf(false) },
     modifier: Modifier = Modifier,
-    expandedContent: @Composable () -> Unit,
-    collapsedContent: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     Column(
         modifier.fillMaxWidth()
             .animateContentSize()
     ) {
-        if (expandedState.value) {
-            expandedContent()
-        } else {
-            collapsedContent()
-        }
+        content()
     }
+}
+
+@Composable
+fun ExpandableText(
+    text: String,
+    maxLines: Int = Integer.MAX_VALUE,
+    expandedState: MutableState<Boolean>,
+    modifier: Modifier = Modifier
+) {
+    fun toggleDescription() {
+        expandedState.value = !expandedState.value
+    }
+
+    ExpandableWidget(content = {
+        AndroidView(viewBlock = { context ->
+            TextView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+                TextViewCompat.setTextAppearance(this, R.style.TextAppearance_App_Body2)
+                ellipsize = TextUtils.TruncateAt.END
+                autoLinkMask = Linkify.ALL
+                setTextColor(Colors.gray400.toArgb())
+                setLinkTextColor(Colors.white.toArgb())
+                setOnTouchListener(ClickTextTouchListener())
+            }
+        }, modifier = modifier) { textView ->
+            textView.maxLines = if (expandedState.value) Integer.MAX_VALUE else maxLines
+            textView.text = StringUtils.styleHtmlText(text = text)
+        }
+
+        CenterRow(modifier = Modifier.clickable(onClick = { toggleDescription() })) {
+            val (expandText, icon) = if (expandedState.value) {
+                stringResource(id = R.string.see_less) to Icons.Filled.ExpandLess
+            } else {
+                stringResource(id = R.string.see_more) to Icons.Filled.ExpandMore
+            }
+            Text(
+                text = expandText,
+                color = Colors.white,
+                fontWeight = FontWeight.Bold
+            )
+            IconButton(onClick = { toggleDescription() }) {
+                Icon(icon, tint = Colors.white)
+            }
+        }
+    })
 }


### PR DESCRIPTION
單集資訊頁 description 展開收合功能
目前已知問題：
當內容有連結時，TextView 即使限制最大行數還是可以滑動的，這部分可以透過 OnTouchListener 解決滑動問題，但仍然沒有 TruncateAt.END 效果

![episode_description](https://user-images.githubusercontent.com/12621026/100857505-b41f0480-34c7-11eb-8038-bfe6ba37fd96.gif)
