### PR TITLE
Add palette util for dynamic theming

### DIFF
--- a/app/src/main/java/tw/jizah/popocast/ui/episode/EpisodeDetail.kt
+++ b/app/src/main/java/tw/jizah/popocast/ui/episode/EpisodeDetail.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.AmbientDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.viewModel
 import dev.chrisbanes.accompanist.coil.CoilImage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,6 +33,9 @@ import tw.jizah.popocast.ui.player.PlayerViewModel
 import tw.jizah.popocast.ui.theme.Colors
 import tw.jizah.popocast.ui.theme.Dimens
 import tw.jizah.popocast.utils.quantityStringResource
+import tw.jizah.popocast.utils.theme.DynamicThemePrimaryColorsFromImage
+import tw.jizah.popocast.utils.theme.rememberDominantColorState
+import tw.jizah.popocast.utils.verticalGradientScrim
 import tw.jizah.popocast.widget.CollapsingHeaderLayout
 import tw.jizah.popocast.widget.EllipsisText
 import tw.jizah.popocast.widget.ExpandableText
@@ -57,40 +61,56 @@ fun EpisodeDetail(
     val appBarHeight = with (AmbientDensity.current) {
         Dimens.toolBarHeight.toIntPx()
     }
+    val dominantColorState = rememberDominantColorState()
+    val channelImageUrl = channel.imageUrl
 
-    Surface(Modifier.fillMaxSize()) {
-        CollapsingHeaderLayout(
-            appBarHeight = appBarHeight,
-            topAppBar = { scrollState, headerHeightState ->
-            EpisodeAppBar(
-                title = episode.itemName,
+    DynamicThemePrimaryColorsFromImage(
+        dominantColorState = dominantColorState
+    ) {
+        if (channelImageUrl.isNotBlank()) {
+            LaunchedEffect(channelImageUrl) {
+                dominantColorState.updateColorsFromImageUrl(channelImageUrl)
+            }
+        }
+
+        Surface(Modifier.fillMaxSize()) {
+            CollapsingHeaderLayout(
                 appBarHeight = appBarHeight,
-                scrollState = scrollState,
-                headerHeightState = headerHeightState,
-                modifier = Modifier.fillMaxWidth().height(Dimens.toolBarHeight)
-            )
-        }, header = {
-            EpisodeHeader(
-                channel = channel,
-                episode = episode,
-                playState = playState,
-                modifier = Modifier.padding(top = Dimens.toolBarHeight).fillMaxWidth()
-            )
-        }, body = {
-            EpisodeButtonBar(
-                isPlaying = isPlayingState,
-                onClickPlay = viewModel::togglePlayOrPause,
-                isItemAdded = isItemAddedState.value,
-                downloadState = downloadState.value,
-                modifier = Modifier.fillMaxWidth()
-            )
-            EpisodeBody(
-                episode = episode,
-                expandedState = expandedState,
-                modifier = Modifier.fillMaxWidth()
-            )
-            SeeAllEpisodes(modifier = Modifier.fillMaxWidth())
-        })
+                topAppBar = { scrollState, headerHeightState ->
+                    EpisodeAppBar(
+                        title = episode.itemName,
+                        appBarHeight = appBarHeight,
+                        scrollState = scrollState,
+                        headerHeightState = headerHeightState,
+                        modifier = Modifier.fillMaxWidth().height(Dimens.toolBarHeight)
+                    )
+                }, header = {
+                    EpisodeHeader(
+                        channel = channel,
+                        episode = episode,
+                        playState = playState,
+                        modifier = Modifier.fillMaxWidth()
+                            .verticalGradientScrim(
+                                color = MaterialTheme.colors.primary.copy(alpha = 0.8f)
+                            )
+                            .padding(top = Dimens.toolBarHeight)
+                    )
+                }, body = {
+                    EpisodeButtonBar(
+                        isPlaying = isPlayingState,
+                        onClickPlay = viewModel::togglePlayOrPause,
+                        isItemAdded = isItemAddedState.value,
+                        downloadState = downloadState.value,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    EpisodeBody(
+                        episode = episode,
+                        expandedState = expandedState,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    SeeAllEpisodes(modifier = Modifier.fillMaxWidth())
+                })
+        }
     }
 }
 
@@ -126,6 +146,7 @@ private fun EpisodeAppBar(
             )
         },
         backgroundColor = Colors.black.copy(alpha = collapseFraction),
+        elevation = 0.dp,
         modifier = modifier
     )
 }

--- a/app/src/main/java/tw/jizah/popocast/utils/GradientScrim.kt
+++ b/app/src/main/java/tw/jizah/popocast/utils/GradientScrim.kt
@@ -1,0 +1,29 @@
+package tw.jizah.popocast.utils
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.VerticalGradient
+
+fun Modifier.verticalGradientScrim(
+    color: Color
+) = composed {
+    val colors = listOf(color.copy(alpha = 0f), color)
+    var height by remember { mutableStateOf(0f) }
+    val brush = remember(color, height) {
+        VerticalGradient(
+            startY = height,
+            endY = 0.0F,
+            colors = colors
+        )
+    }
+    drawBehind {
+        height = size.height
+        drawRect(brush = brush)
+    }
+}

--- a/app/src/main/java/tw/jizah/popocast/utils/theme/DominantColorCache.kt
+++ b/app/src/main/java/tw/jizah/popocast/utils/theme/DominantColorCache.kt
@@ -1,0 +1,14 @@
+package tw.jizah.popocast.utils.theme
+
+import androidx.collection.LruCache
+
+object DominantColorCache {
+    private const val CACHE_SIZE = 10
+    private val LRU_CACHE: LruCache<String, DominantColors> = LruCache(CACHE_SIZE)
+
+    fun setColors(key: String, dominantColors: DominantColors) {
+        LRU_CACHE.put(key, dominantColors)
+    }
+
+    fun getColors(key: String): DominantColors? = LRU_CACHE[key]
+}

--- a/app/src/main/java/tw/jizah/popocast/utils/theme/DominantColorState.kt
+++ b/app/src/main/java/tw/jizah/popocast/utils/theme/DominantColorState.kt
@@ -1,0 +1,73 @@
+package tw.jizah.popocast.utils.theme
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.core.graphics.drawable.toBitmap
+import androidx.palette.graphics.Palette
+import coil.Coil
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import coil.size.Scale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class DominantColorState(
+    private val context: Context,
+    private val defaultColor: Color,
+) {
+
+    private val requestImageSize = 128
+    private val maximumPaletteColorCount = 8
+
+    var color by mutableStateOf(defaultColor)
+        private set
+
+    suspend fun updateColorsFromImageUrl(url: String) {
+        val result = calculateDominantColor(url)
+        color = result?.color ?: defaultColor
+    }
+
+    private suspend fun calculateDominantColor(url: String): DominantColors? {
+        val cached = DominantColorCache.getColors(url)
+        if (cached != null) {
+            return cached
+        }
+
+        return calculateSwatchesInImage(context, url)
+            .maxByOrNull { swatch -> swatch.population }
+            ?.let { swatch -> DominantColors(color = Color(swatch.rgb)) }
+            ?.also { result -> DominantColorCache.setColors(url, result) }
+    }
+
+    private suspend fun calculateSwatchesInImage(
+        context: Context,
+        imageUrl: String
+    ): List<Palette.Swatch> {
+        val request = ImageRequest.Builder(context)
+            .data(imageUrl)
+            .size(requestImageSize)
+            .scale(Scale.FILL)
+            // Disable hardware bitmaps, since Palette uses Bitmap.getPixels()
+            .allowHardware(false)
+            .build()
+
+        val bitmap = when (val result = Coil.execute(request)) {
+            is SuccessResult -> result.drawable.toBitmap()
+            else -> null
+        }
+
+        return bitmap?.let {
+            withContext(Dispatchers.Default) {
+                val palette = Palette.Builder(bitmap)
+                    // Disable any bitmap resizing in Palette.
+                    .resizeBitmapArea(0)
+                    .maximumColorCount(maximumPaletteColorCount)
+                    .generate()
+                palette.swatches
+            }
+        } ?: emptyList()
+    }
+}

--- a/app/src/main/java/tw/jizah/popocast/utils/theme/DominantColors.kt
+++ b/app/src/main/java/tw/jizah/popocast/utils/theme/DominantColors.kt
@@ -1,0 +1,5 @@
+package tw.jizah.popocast.utils.theme
+
+import androidx.compose.ui.graphics.Color
+
+data class DominantColors(val color: Color)

--- a/app/src/main/java/tw/jizah/popocast/utils/theme/DynamicTheming.kt
+++ b/app/src/main/java/tw/jizah/popocast/utils/theme/DynamicTheming.kt
@@ -1,0 +1,30 @@
+package tw.jizah.popocast.utils.theme
+
+import android.content.Context
+import androidx.compose.animation.animate
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.AmbientContext
+
+@Composable
+fun DynamicThemePrimaryColorsFromImage(
+    dominantColorState: DominantColorState = rememberDominantColorState(),
+    content: @Composable () -> Unit
+) {
+    val colors = MaterialTheme.colors.copy(
+        primary = animate(dominantColorState.color, spring(stiffness = Spring.StiffnessLow)),
+    )
+    MaterialTheme(colors = colors, content = content)
+}
+
+@Composable
+fun rememberDominantColorState(
+    context: Context = AmbientContext.current,
+    defaultColor: Color = MaterialTheme.colors.primary
+): DominantColorState = remember {
+    DominantColorState(context, defaultColor)
+}


### PR DESCRIPTION
1. 新增調色盤工具
功能：
- 根據 image 找出 dominant color，會撇除**近黑色**跟**近白色**
- 會將計算過的 image dominant color 暫存，cache 為 app 內共用，key 是 image url

2. 幫單集資訊頁加上漸層背景

![device-2020-12-14-172859](https://user-images.githubusercontent.com/12621026/102064963-e66b2300-3e32-11eb-8e62-13d102732909.gif)
